### PR TITLE
Fixed connection.config bug

### DIFF
--- a/Gilligan.API/Gilligan.API.Tests.Integration/Gilligan.API.Tests.Integration.csproj
+++ b/Gilligan.API/Gilligan.API.Tests.Integration/Gilligan.API.Tests.Integration.csproj
@@ -99,9 +99,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="connections.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
There was an extra config file that could not be found in the integration test that I deleted, so the project would build.